### PR TITLE
setへの値を渡す際にintとdoubleに対応

### DIFF
--- a/Ambient.cpp
+++ b/Ambient.cpp
@@ -54,7 +54,7 @@ Ambient::begin(unsigned int channelId, const char * writeKey, WiFiClient * c, in
 }
 
 bool
-Ambient::set(int field, char * data) {
+Ambient::set(int field,const char * data) {
     --field;
     if (field < 0 || field >= AMBIENT_NUM_PARAMS) {
         return false;
@@ -66,6 +66,16 @@ Ambient::set(int field, char * data) {
     strcpy(this->data[field].item, data);
 
     return true;
+}
+
+bool Ambient::set(int field, double data)
+{
+	return set(field,String(data).c_str());
+}
+
+bool Ambient::set(int field, int data)
+{
+	return set(field, String(data).c_str());
 }
 
 bool

--- a/Ambient.h
+++ b/Ambient.h
@@ -21,7 +21,9 @@ public:
     Ambient(void);
 
     bool begin(unsigned int channelId, const char * writeKey, WiFiClient * c, int dev = 0);
-    bool set(int field, char * data);
+    bool set(int field,const char * data);
+	bool set(int field, double data);
+	bool set(int field, int data);
     bool clear(int field);
 
     bool send(void);


### PR DESCRIPTION
今まではわざわざ型変換して渡さなくてはいけないところをintとdoubleのみであるが、そのまま渡すことができるようにしたことでよりAmbientをより手軽に扱うことができる。